### PR TITLE
Add five repositories of other kinds to the regression corpus

### DIFF
--- a/tests/regression/expected/dvpwa.json
+++ b/tests/regression/expected/dvpwa.json
@@ -1,0 +1,34 @@
+{
+  "coverage": {
+    "files": 21,
+    "files_analysed": 21,
+    "functions": 48,
+    "functions_analysed": 48
+  },
+  "findings": [
+    {
+      "file": "config/dev.yaml",
+      "line": 3,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "requirements.txt",
+      "line": 11,
+      "rule": "vulnerable-dependency",
+      "function": null
+    },
+    {
+      "file": "requirements.txt",
+      "line": 15,
+      "rule": "vulnerable-dependency",
+      "function": null
+    },
+    {
+      "file": "sqli/dao/user.py",
+      "line": 41,
+      "rule": "weak-crypto",
+      "function": "check_password"
+    }
+  ]
+}

--- a/tests/regression/expected/full-stack-fastapi-template.json
+++ b/tests/regression/expected/full-stack-fastapi-template.json
@@ -1,0 +1,82 @@
+{
+  "coverage": {
+    "files": 43,
+    "files_analysed": 41,
+    "functions": 139,
+    "functions_analysed": 139
+  },
+  "findings": [
+    {
+      "file": ".env",
+      "line": 6,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": ".env",
+      "line": 8,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": ".env",
+      "line": 17,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": ".env",
+      "line": 18,
+      "rule": "hardcoded-secret",
+      "function": null
+    },
+    {
+      "file": "backend/app/api/deps.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "backend/app/api/routes/login.py",
+      "line": 121,
+      "rule": "xss",
+      "function": "recover_password_html_content"
+    },
+    {
+      "file": "backend/app/api/routes/login.py",
+      "line": 121,
+      "rule": "xss",
+      "function": "recover_password_html_content"
+    },
+    {
+      "file": "backend/app/models.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "backend/tests/api/routes/test_login.py",
+      "line": 31,
+      "rule": "hardcoded-credential",
+      "function": "test_get_access_token_incorrect_password"
+    },
+    {
+      "file": "backend/tests/api/routes/test_login.py",
+      "line": 116,
+      "rule": "hardcoded-credential",
+      "function": "test_reset_password_invalid_token"
+    },
+    {
+      "file": "backend/tests/api/routes/test_login.py",
+      "line": 116,
+      "rule": "hardcoded-credential",
+      "function": "test_reset_password_invalid_token"
+    },
+    {
+      "file": "backend/tests/api/routes/test_private.py",
+      "line": 13,
+      "rule": "hardcoded-credential",
+      "function": "test_create_user"
+    }
+  ]
+}

--- a/tests/regression/expected/httpie.json
+++ b/tests/regression/expected/httpie.json
@@ -1,0 +1,76 @@
+{
+  "coverage": {
+    "files": 132,
+    "files_analysed": 129,
+    "functions": 1016,
+    "functions_analysed": 1016
+  },
+  "findings": [
+    {
+      "file": "docs/contributors/fetch.py",
+      "line": 200,
+      "rule": "missing-timeout",
+      "function": "fetch"
+    },
+    {
+      "file": "extras/profiling/run.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "httpie/client.py",
+      "line": 114,
+      "rule": "ssrf",
+      "function": "collect_messages"
+    },
+    {
+      "file": "httpie/client.py",
+      "line": 114,
+      "rule": "ssrf",
+      "function": "collect_messages"
+    },
+    {
+      "file": "httpie/internal/daemons.py",
+      "line": 121,
+      "rule": "command-injection",
+      "function": "spawn_daemon"
+    },
+    {
+      "file": "httpie/internal/update_warnings.py",
+      "line": 44,
+      "rule": "missing-timeout",
+      "function": "_fetch_updates"
+    },
+    {
+      "file": "httpie/output/streams.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "tests/test_binary.py",
+      "line": 49,
+      "rule": "missing-timeout",
+      "function": "test_binary_included_and_correct_when_suitable"
+    },
+    {
+      "file": "tests/test_json.py",
+      "line": 41,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "tests/test_output.py",
+      "line": 163,
+      "rule": "missing-timeout",
+      "function": "test_quiet_with_output_redirection"
+    },
+    {
+      "file": "tests/test_uploads.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    }
+  ]
+}

--- a/tests/regression/expected/luigi.json
+++ b/tests/regression/expected/luigi.json
@@ -1,0 +1,430 @@
+{
+  "coverage": {
+    "files": 259,
+    "files_analysed": 245,
+    "functions": 4462,
+    "functions_analysed": 4462
+  },
+  "findings": [
+    {
+      "file": "examples/ftp_experiment_outputs.py",
+      "line": 25,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "examples/top_artists.py",
+      "line": 249,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "luigi/contrib/beam_dataflow.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/contrib/esindex.py",
+      "line": 159,
+      "rule": "weak-crypto",
+      "function": "marker_index_document_id"
+    },
+    {
+      "file": "luigi/contrib/hdfs/abstract_client.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/contrib/hive.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/contrib/lsf.py",
+      "line": 263,
+      "rule": "command-injection",
+      "function": "_run_job"
+    },
+    {
+      "file": "luigi/contrib/lsf.py",
+      "line": 263,
+      "rule": "path-traversal",
+      "function": "_run_job"
+    },
+    {
+      "file": "luigi/contrib/lsf.py",
+      "line": 274,
+      "rule": "path-traversal",
+      "function": "_run_job"
+    },
+    {
+      "file": "luigi/contrib/pai.py",
+      "line": 229,
+      "rule": "missing-timeout",
+      "function": "__init_token"
+    },
+    {
+      "file": "luigi/contrib/pai.py",
+      "line": 247,
+      "rule": "missing-timeout",
+      "function": "__check_job_status"
+    },
+    {
+      "file": "luigi/contrib/pai.py",
+      "line": 280,
+      "rule": "missing-timeout",
+      "function": "run"
+    },
+    {
+      "file": "luigi/contrib/pig.py",
+      "line": 134,
+      "rule": "command-injection",
+      "function": "track_and_progress"
+    },
+    {
+      "file": "luigi/contrib/presto.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/contrib/pyspark_runner.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 258,
+      "rule": "missing-timeout",
+      "function": "start_session"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 286,
+      "rule": "missing-timeout",
+      "function": "query"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 312,
+      "rule": "missing-timeout",
+      "function": "query_more"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 373,
+      "rule": "missing-timeout",
+      "function": "restful"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 394,
+      "rule": "missing-timeout",
+      "function": "create_operation_job"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 412,
+      "rule": "missing-timeout",
+      "function": "get_job_details"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 426,
+      "rule": "missing-timeout",
+      "function": "abort_job"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 441,
+      "rule": "missing-timeout",
+      "function": "close_job"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 465,
+      "rule": "missing-timeout",
+      "function": "create_batch"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 512,
+      "rule": "missing-timeout",
+      "function": "get_batch_result_ids"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 528,
+      "rule": "missing-timeout",
+      "function": "get_batch_result"
+    },
+    {
+      "file": "luigi/contrib/salesforce.py",
+      "line": 534,
+      "rule": "missing-timeout",
+      "function": "_get_batch_info"
+    },
+    {
+      "file": "luigi/contrib/scalding.py",
+      "line": 211,
+      "rule": "command-injection",
+      "function": "run_job"
+    },
+    {
+      "file": "luigi/contrib/sge.py",
+      "line": 291,
+      "rule": "path-traversal",
+      "function": "_run_job"
+    },
+    {
+      "file": "luigi/contrib/sge.py",
+      "line": 296,
+      "rule": "command-injection",
+      "function": "_run_job"
+    },
+    {
+      "file": "luigi/metrics.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/parameter.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/rpc.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/target.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/task.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "luigi/task_history.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "test/_test_ftp.py",
+      "line": 43,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/cmdline_test.py",
+      "line": 213,
+      "rule": "command-injection",
+      "function": "_run_cmdline"
+    },
+    {
+      "file": "test/contrib/beam_dataflow_test.py",
+      "line": 161,
+      "rule": "high-entropy-string",
+      "function": "test_dataflow_full_cmd_line_args"
+    },
+    {
+      "file": "test/contrib/mysqldb_test.py",
+      "line": 41,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/contrib/pai_test.py",
+      "line": 62,
+      "rule": "hardcoded-credential",
+      "function": "test_success"
+    },
+    {
+      "file": "test/contrib/pai_test.py",
+      "line": 80,
+      "rule": "hardcoded-credential",
+      "function": "test_fail"
+    },
+    {
+      "file": "test/contrib/postgres_test.py",
+      "line": 56,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/contrib/postgres_test.py",
+      "line": 96,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/contrib/postgres_with_server_test.py",
+      "line": 40,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/contrib/rdbms_test.py",
+      "line": 46,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/contrib/redshift_test.py",
+      "line": 62,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/contrib/redshift_test.py",
+      "line": 90,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/contrib/redshift_test.py",
+      "line": 150,
+      "rule": "hardcoded-credential",
+      "function": "test_from_env"
+    },
+    {
+      "file": "test/contrib/redshift_test.py",
+      "line": 155,
+      "rule": "hardcoded-credential",
+      "function": "test_from_config"
+    },
+    {
+      "file": "test/contrib/redshift_test.py",
+      "line": 494,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/contrib/redshift_test.py",
+      "line": 502,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/contrib/redshift_test.py",
+      "line": 537,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/event_callbacks_test.py",
+      "line": 189,
+      "rule": "dangerous-eval",
+      "function": "eval_contents"
+    },
+    {
+      "file": "test/notifications_test.py",
+      "line": 405,
+      "rule": "hardcoded-credential",
+      "function": "test_sends_smtp_email"
+    },
+    {
+      "file": "test/notifications_test.py",
+      "line": 438,
+      "rule": "hardcoded-credential",
+      "function": "test_sends_smtp_email_with_images_png"
+    },
+    {
+      "file": "test/notifications_test.py",
+      "line": 476,
+      "rule": "hardcoded-credential",
+      "function": "test_sends_smtp_email_without_tls"
+    },
+    {
+      "file": "test/notifications_test.py",
+      "line": 509,
+      "rule": "hardcoded-credential",
+      "function": "test_sends_smtp_email_exceptions"
+    },
+    {
+      "file": "test/notifications_test.py",
+      "line": 548,
+      "rule": "hardcoded-credential",
+      "function": "test_sends_sendgrid_email"
+    },
+    {
+      "file": "test/notifications_test.py",
+      "line": 561,
+      "rule": "hardcoded-credential",
+      "function": "test_sends_sendgrid_email_with_multiple_images"
+    },
+    {
+      "file": "test/notifications_test.py",
+      "line": 591,
+      "rule": "hardcoded-credential",
+      "function": "test_sendgrid_with_empty_images_list_does_not_attach"
+    },
+    {
+      "file": "test/notifications_test.py",
+      "line": 598,
+      "rule": "hardcoded-credential",
+      "function": "test_sends_sendgrid_email_with_image_png_kwarg"
+    },
+    {
+      "file": "test/range_test.py",
+      "line": 1119,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/range_test.py",
+      "line": 1553,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "test/rpc_test.py",
+      "line": 196,
+      "rule": "hardcoded-secret",
+      "function": "test_url_with_basic_auth"
+    },
+    {
+      "file": "test/scheduler_api_test.py",
+      "line": 1653,
+      "rule": "high-entropy-string",
+      "function": "test_task_list_filter_by_search_long_family_name"
+    },
+    {
+      "file": "test/task_test.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "test/worker_scheduler_com_test.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "test/worker_test.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "tox.ini",
+      "line": 55,
+      "rule": "hardcoded-credential",
+      "function": null
+    }
+  ]
+}

--- a/tests/regression/expected/pygoat.json
+++ b/tests/regression/expected/pygoat.json
@@ -1,0 +1,328 @@
+{
+  "coverage": {
+    "files": 78,
+    "files_analysed": 76,
+    "functions": 170,
+    "functions_analysed": 170
+  },
+  "findings": [
+    {
+      "file": "challenge/views.py",
+      "line": 50,
+      "rule": "command-injection",
+      "function": "post"
+    },
+    {
+      "file": "challenge/views.py",
+      "line": 81,
+      "rule": "command-injection",
+      "function": "delete"
+    },
+    {
+      "file": "dockerized_labs/broken_auth_lab/app.py",
+      "line": 8,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "dockerized_labs/broken_auth_lab/app.py",
+      "line": 13,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "dockerized_labs/broken_auth_lab/app.py",
+      "line": 18,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "dockerized_labs/broken_auth_lab/app.py",
+      "line": 86,
+      "rule": "weak-crypto",
+      "function": "reset_password"
+    },
+    {
+      "file": "dockerized_labs/broken_auth_lab/app.py",
+      "line": 123,
+      "rule": "debug-enabled",
+      "function": null
+    },
+    {
+      "file": "dockerized_labs/sensitive_data_exposure/sensitive_data_lab/settings.py",
+      "line": 8,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "introduction/apis.py",
+      "line": 38,
+      "rule": "path-traversal",
+      "function": "ssrf_code_checker"
+    },
+    {
+      "file": "introduction/apis.py",
+      "line": 81,
+      "rule": "missing-timeout",
+      "function": "log_function_checker"
+    },
+    {
+      "file": "introduction/apis.py",
+      "line": 82,
+      "rule": "missing-timeout",
+      "function": "log_function_checker"
+    },
+    {
+      "file": "introduction/apis.py",
+      "line": 83,
+      "rule": "missing-timeout",
+      "function": "log_function_checker"
+    },
+    {
+      "file": "introduction/apis.py",
+      "line": 83,
+      "rule": "ssrf",
+      "function": "log_function_checker"
+    },
+    {
+      "file": "introduction/apis.py",
+      "line": 84,
+      "rule": "missing-timeout",
+      "function": "log_function_checker"
+    },
+    {
+      "file": "introduction/mitre.py",
+      "line": 161,
+      "rule": "weak-crypto",
+      "function": "csrf_lab_login"
+    },
+    {
+      "file": "introduction/mitre.py",
+      "line": 218,
+      "rule": "dangerous-eval",
+      "function": "mitre_lab_25_api"
+    },
+    {
+      "file": "introduction/mitre.py",
+      "line": 242,
+      "rule": "command-injection",
+      "function": "mitre_lab_17_api"
+    },
+    {
+      "file": "introduction/playground/A6/soln.py",
+      "line": 9,
+      "rule": "missing-timeout",
+      "function": "check_vuln"
+    },
+    {
+      "file": "introduction/playground/A6/utility.py",
+      "line": 9,
+      "rule": "missing-timeout",
+      "function": "check_vuln"
+    },
+    {
+      "file": "introduction/playground/A9/api.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "introduction/playground/A9/archive.py",
+      "line": 1,
+      "rule": "syntax-error",
+      "function": null
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 162,
+      "rule": "sql-injection",
+      "function": "sql_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 214,
+      "rule": "insecure-deserialization",
+      "function": "insec_des_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 290,
+      "rule": "xss",
+      "function": "auth_lab_signup"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 304,
+      "rule": "xss",
+      "function": "auth_lab_login"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 318,
+      "rule": "xss",
+      "function": "auth_lab_login"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 430,
+      "rule": "command-injection",
+      "function": "cmd_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 460,
+      "rule": "dangerous-eval",
+      "function": "cmd_lab2"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 538,
+      "rule": "hardcoded-credential",
+      "function": "secret"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 560,
+      "rule": "exploitable-vulnerability",
+      "function": "a9_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 560,
+      "rule": "insecure-deserialization",
+      "function": "a9_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 560,
+      "rule": "reachable-vulnerability",
+      "function": "a9_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 584,
+      "rule": "exploitable-vulnerability",
+      "function": "a9_lab2"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 584,
+      "rule": "reachable-vulnerability",
+      "function": "a9_lab2"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 866,
+      "rule": "hardcoded-credential",
+      "function": "injection_sql_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 868,
+      "rule": "hardcoded-credential",
+      "function": "injection_sql_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 870,
+      "rule": "hardcoded-credential",
+      "function": "injection_sql_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 872,
+      "rule": "hardcoded-credential",
+      "function": "injection_sql_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 878,
+      "rule": "sql-injection",
+      "function": "injection_sql_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 927,
+      "rule": "path-traversal",
+      "function": "ssrf_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 963,
+      "rule": "missing-timeout",
+      "function": "ssrf_lab2"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 963,
+      "rule": "ssrf",
+      "function": "ssrf_lab2"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 1026,
+      "rule": "weak-crypto",
+      "function": "crypto_failure_lab"
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 1164,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 1165,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 1166,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "introduction/views.py",
+      "line": 1167,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "pygoat/settings.py",
+      "line": 25,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "pygoat/settings.py",
+      "line": 171,
+      "rule": "hardcoded-credential",
+      "function": null
+    },
+    {
+      "file": "requirements.txt",
+      "line": 19,
+      "rule": "vulnerable-dependency",
+      "function": null
+    },
+    {
+      "file": "requirements.txt",
+      "line": 27,
+      "rule": "vulnerable-dependency",
+      "function": null
+    },
+    {
+      "file": "requirements.txt",
+      "line": 32,
+      "rule": "vulnerable-dependency",
+      "function": null
+    },
+    {
+      "file": "requirements.txt",
+      "line": 32,
+      "rule": "vulnerable-dependency",
+      "function": null
+    }
+  ]
+}

--- a/tests/regression/repositories.toml
+++ b/tests/regression/repositories.toml
@@ -68,6 +68,34 @@ name = "healthchecks"
 url = "https://github.com/healthchecks/healthchecks.git"
 commit = "69dbd2a0801dfbcfcd554af8cbbdaaab0b39e2a3"
 
+# Other kinds of projects: an intentionally vulnerable aiohttp application, an
+# intentionally vulnerable Django application, the FastAPI full-stack template, an HTTP
+# client command-line tool and a data-pipeline framework with its workers.
+[[repository]]
+name = "dvpwa"
+url = "https://github.com/anxolerd/dvpwa.git"
+commit = "a1d8f89fac2e57093189853c6527c2b01fc1d9c1"
+
+[[repository]]
+name = "pygoat"
+url = "https://github.com/adeyosemanputra/pygoat.git"
+commit = "19d17cc8874861142b330636d068bbde54e86b85"
+
+[[repository]]
+name = "full-stack-fastapi-template"
+url = "https://github.com/fastapi/full-stack-fastapi-template.git"
+commit = "cb740b656d7a0a6c5e12c7bf8e50343ec94ee9c7"
+
+[[repository]]
+name = "httpie"
+url = "https://github.com/httpie/cli.git"
+commit = "5b604c37c6c67e18e7c3e9aee6c88a8c22b98345"
+
+[[repository]]
+name = "luigi"
+url = "https://github.com/spotify/luigi.git"
+commit = "715f65c4a56a908ef0a1df4df6fc33b8420e2e6c"
+
 # Intentionally vulnerable Flask fixture kept in the tree.
 [[repository]]
 name = "vulnerable-flask"


### PR DESCRIPTION
## Summary

Corpus item of #71: five public repositories of other kinds join the regression suite.

| Repository | Kind | Lines | Findings |
|---|---|---:|---:|
| dvpwa | intentionally vulnerable aiohttp application | 700 | 4 |
| pygoat | intentionally vulnerable Django application | 4 000 | 53 |
| full-stack-fastapi-template | FastAPI backend template | 2 900 | 12 |
| httpie | HTTP client command-line tool | 19 000 | 11 |
| luigi | data-pipeline framework and workers | 63 000 | 70 |

- Every finding was read against the code. pygoat's labs are all found: command injection through `subprocess.Popen`, SQL injection through `objects.raw`, SSRF, `pickle` and `yaml.load` deserialization (the latter correlated with the required vulnerable PyYAML), path traversal, reflected XSS through `HttpResponse`, `eval`, `debug=True`.
- The corpus also exposes gaps, recorded as tasks on #71 and #70 and left as they are in the snapshots so the fixes show their effect: class keyword arguments and `with` targets other than a name reject whole files (15 files); `environment` and `process-output` sources are operator-controlled and should not carry `COMMAND` and `PATH` (httpie's daemon, luigi's contrib modules); dvpwa's SQL injections and XSS are silent because aiohttp has no models yet.
- The whole regression suite now covers 19 repositories, 280 findings, and runs in about a minute.

Part of #71.
